### PR TITLE
Update typespecs for `Cachex.put/4` and `Cachex.put_many/3`

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -956,7 +956,7 @@ defmodule Cachex do
       { :ok, 5000 }
 
   """
-  @spec put(Cachex.t(), any, any, Keyword.t()) :: {status, boolean}
+  @spec put(Cachex.t(), any, any, Keyword.t()) :: {status, any}
   def put(cache, key, value, options \\ []) when is_list(options),
     do: Router.route(cache, {:put, [key, value, options]})
 
@@ -985,7 +985,7 @@ defmodule Cachex do
       { :ok, 5000 }
 
   """
-  @spec put_many(Cachex.t(), [{any, any}], Keyword.t()) :: {status, boolean}
+  @spec put_many(Cachex.t(), [{any, any}], Keyword.t()) :: {status, any}
   def put_many(cache, pairs, options \\ [])
       when is_list(pairs) and is_list(options),
       do: Router.route(cache, {:put_many, [pairs, options]})


### PR DESCRIPTION
These functions both define a return type of `{status, boolean}`, but both may return e.g. `{:error, :no_cache}`, such as when an invalid cache name is given:

```
 iex> Cachex.put(:hello, :world, :ok)
{:error, :no_cache}
```

```
 iex> Cachex.put_many(:hello, [{:world, :ok}])
{:error, :no_cache}
```

This pull requests loosens the return type a bit to use `{status, any}`.